### PR TITLE
Prepend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,3 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in timeout.gemspec
 gemspec
 
-gem "celluloid", github: "celluloid/celluloid"

--- a/lib/timeout/extensions.rb
+++ b/lib/timeout/extensions.rb
@@ -1,45 +1,52 @@
 require 'timeout/extensions/version'
 
+# Core extensions to Thread
+# 
+# Adds accessors to customize timeout and sleep within a thread,
+# if you have a better friendlier implementation of both methods,
+# or if your code breaks with the stdlib implementations. 
+# 
 class Thread
   attr_accessor :timeout_handler
   attr_accessor :sleep_handler
 end
 
 module Timeout::Extensions
-  def self.extended(mod)
-    mod.singleton_class.class_eval do
-      alias_method :timeout_without_handler, :timeout
-      alias_method :timeout, :timeout_with_handler
+  module TimeoutMethods
+    def timeout(*args, &block)
+      if timeout_handler = Thread.current.timeout_handler
+        timeout_handler.call(*args, &block)
+      else
+        super
+      end
     end
   end
 
-  def timeout_with_handler(*args, &block)
-    if timeout_handler = Thread.current.timeout_handler
-      timeout_handler.call(*args, &block)
-    else
-      timeout_without_handler(*args, &block)
+  module KernelMethods
+    def sleep(*args)
+      if sleep_handler = Thread.current.sleep_handler
+        sleep_handler.call(*args)
+      else
+        super
+      end
     end
   end
-  module_function :timeout_with_handler
-  public :timeout_with_handler
+
+  # in order for prepend to work, I have to do it in the Timeout module singleton class
+  class << ::Timeout
+    prepend TimeoutMethods
+  end
+  
+  # ditto for Kernel
+  class << ::Kernel
+    prepend KernelMethods
+  end
+  
+  # this is an hack so that calling "sleep(2)" works. Amazingly, the message doesn't get
+  # sent to Kernel.sleep code path. 
+  # https://bugs.ruby-lang.org/issues/12535
+  #
+  ::Object.prepend KernelMethods
 end
 
-module Kernel::Extensions
-  def self.included(mod)
-    mod.class_eval do
-      alias_method :sleep_without_handler, :sleep
-      alias_method :sleep, :sleep_with_handler
-    end
-  end
 
-  def sleep_with_handler(*args)
-    if sleep_handler = Thread.current.sleep_handler
-      sleep_handler.call(*args)
-    else
-      sleep_without_handler(*args)
-    end
-  end
-end
-
-Timeout.extend Timeout::Extensions
-include Kernel::Extensions

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'timeout/extensions'
 
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,25 +3,6 @@ require 'bundler/setup'
 require 'logger'
 require 'timeout'
 require 'timeout/extensions'
-require 'celluloid/autostart'
-require 'celluloid/rspec'
-
-logfile = File.open(File.expand_path("../../log/test.log", __FILE__), 'a')
-logfile.sync = true
-
-logger = Celluloid.logger = Logger.new(logfile)
-
-Celluloid.shutdown_timeout = 1 
-
-
-class Celluloid::Actor
-  # Important that these two are left out, or else
-  # timeout calls inside the actor scope will never propagate
-  # to the proper extensions
-  # TODO: eventually remove this if celluloid adopts the gem
-  undef_method :timeout if instance_methods(false).include?(:timeout)
-  undef_method :sleep if instance_methods(false).include?(:sleep)
-end
 
 
 RSpec.configure do |config|
@@ -30,33 +11,18 @@ RSpec.configure do |config|
   config.filter_run :focus
 
   config.before do
-    Celluloid.logger = logger
-    Celluloid.shutdown
-    sleep 0.01
-
-    Celluloid.boot
-
-    FileUtils.rm("/tmp/cell_sock") if File.exist?("/tmp/cell_sock")
     include Timeout::Extensions
   end
 
   config.order = 'random'
 end
 
-class ExampleActor
-  include Celluloid
-  execute_block_on_receiver :wrap
 
-  def wrap
+
+def within_thread(&block)
+  Thread.new do
     yield
-  end
-end
-
-def within_actor(&block)
-  actor = ExampleActor.new
-  actor.wrap(&block)
-ensure
-  actor.terminate if actor and actor.alive?
+  end.join
 end
 
 

--- a/spec/timeout/extensions_spec.rb
+++ b/spec/timeout/extensions_spec.rb
@@ -7,7 +7,7 @@ describe Timeout::Extensions do
     let(:action) { Proc.new{ |t|  } }
     context "inside and outside of actor" do
       it "hits the proper timeout handler" do
-        within_actor do
+        within_thread do
           Thread.current.timeout_handler = dummy_timeout
           expect(dummy_timeout).to receive(:call).with(2, exception, &action)
           timeout(2, exception, &action)
@@ -22,7 +22,7 @@ describe Timeout::Extensions do
     let(:dummy_sleep) { double(:meta_sleep) }
     context "inside and outside of actor" do
       it "hits the proper sleep handler" do
-        within_actor do
+        within_thread do
           Thread.current.sleep_handler = dummy_sleep
           expect(dummy_sleep).to receive(:call).with(2)
           sleep(2)

--- a/spec/timeout/extensions_spec.rb
+++ b/spec/timeout/extensions_spec.rb
@@ -1,34 +1,30 @@
 require 'spec_helper'
 
-describe Timeout::Extensions do
-  describe "timeout" do
+RSpec.describe Timeout::Extensions do
+  describe ".timeout" do
     let(:dummy_timeout) { double(:meta_timeout) }
     let(:exception) { double(:exception) }
     let(:action) { Proc.new{ |t|  } }
-    context "inside and outside of actor" do
+    context "inside and outside of thread" do
       it "hits the proper timeout handler" do
         within_thread do
           Thread.current.timeout_handler = dummy_timeout
           expect(dummy_timeout).to receive(:call).with(2, exception, &action)
           timeout(2, exception, &action)
         end
-        expect(Timeout).to receive(:timeout_without_handler)
-        timeout(2, exception, &action)
       end
     end
   end
 
-  describe "sleep" do
+  describe ".sleep" do
     let(:dummy_sleep) { double(:meta_sleep) }
-    context "inside and outside of actor" do
+    context "inside and outside of thread" do
       it "hits the proper sleep handler" do
         within_thread do
           Thread.current.sleep_handler = dummy_sleep
           expect(dummy_sleep).to receive(:call).with(2)
           sleep(2)
         end
-        expect(self).to receive(:sleep_without_handler)
-        sleep(2)
       end
     end
   end 

--- a/timeout-extensions.gemspec
+++ b/timeout-extensions.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = "A timeout extension for Ruby which plugs into multiple timeout backends"
   spec.homepage      = "https://github.com/celluloid/timeout-extensions"
   spec.license       = "MIT"
+  spec.required_ruby_version = ">= 2.0.0"
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }

--- a/timeout-extensions.gemspec
+++ b/timeout-extensions.gemspec
@@ -21,5 +21,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", 		"~> 10.4.2"
   spec.add_development_dependency "pry",		"~> 0.10.1"
   spec.add_development_dependency "rspec", 	 	"~> 2.14.0"
-  spec.add_development_dependency "celluloid",  ">= 0.16.0"
 end

--- a/timeout-extensions.gemspec
+++ b/timeout-extensions.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake", 		"~> 10.4.2"
-  spec.add_development_dependency "pry",		"~> 0.10.1"
-  spec.add_development_dependency "rspec", 	 	"~> 2.14.0"
+  spec.add_development_dependency "pry",   		"~> 0.10.1"
+  spec.add_development_dependency "rspec", 	 	"~> 3.4.0"
 end


### PR DESCRIPTION
Rewrote internal logic to not rely anymore on method overwrites, but using just Module#prepend.

This breaks ruby <2.0.0 support, but as even 2.0.0 is EOL, it's only a good thing. 

Tried rewriting the approach with refinements, but one can't unfortunately refine modules (like Timeout or Kernel). 

@tarcieri  could you maybe cut a release once you're done reviewing? I'm assuming it won't be a big deal. 